### PR TITLE
Add conan 2 recipe that exports the header lib and the tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 build/
 out/
 cmake-build-*/
+CMakeUserPresets.json
 
 # IDE files
 .vs/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,8 +29,11 @@ include(ProjectOptions.cmake)
 json2cpp_setup_options()
 
 json2cpp_global_options()
-include(Dependencies.cmake)
-json2cpp_setup_dependencies()
+
+if(NOT DEFINED CONAN_CXX_FLAGS)
+  include(Dependencies.cmake)
+  json2cpp_setup_dependencies()
+endif()
 
 json2cpp_local_options()
 
@@ -48,9 +51,24 @@ string(
 
 target_compile_features(json2cpp_options INTERFACE cxx_std_${CMAKE_CXX_STANDARD})
 
+if(DEFINED CONAN_CXX_FLAGS)
+  find_package(ValiJSON CONFIG)
+endif()
+
 add_library(json2cpp_headers INTERFACE)
-target_include_directories(json2cpp_headers INTERFACE "${CMAKE_SOURCE_DIR}/include")
+target_include_directories(json2cpp_headers INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>)
+target_link_libraries(json2cpp_headers INTERFACE ValiJSON::valijson)
+install(DIRECTORY "${CMAKE_SOURCE_DIR}/include/json2cpp" TYPE INCLUDE)
 add_library(json2cpp::json2cpp_headers ALIAS json2cpp_headers)
+install(TARGETS json2cpp_headers EXPORT json2cppTargets)
+export(EXPORT json2cppTargets NAMESPACE json2cpp::)
+install(
+  EXPORT json2cppTargets
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/json2cpp
+  NAMESPACE json2cpp::
+)
 
 add_library(json2cpp::json2cpp_options ALIAS json2cpp_options)
 add_library(json2cpp::json2cpp_warnings ALIAS json2cpp_warnings)
@@ -93,6 +111,10 @@ endif()
 set_property(DIRECTORY PROPERTY VS_STARTUP_PROJECT json2cpp)
 
 if(CMAKE_SKIP_INSTALL_RULES)
+  return()
+endif()
+
+if(DEFINED CONAN_CXX_FLAGS)
   return()
 endif()
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,74 @@
+import os
+
+from conan import ConanFile
+from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout, CMakeDeps
+from conan.tools.files import copy
+
+
+class json2cppRecipe(ConanFile):
+    name = "json2cpp"
+    version = "0.0.1"
+    package_type = "header-library"
+
+    # Optional metadata
+    license = "MIT"
+    author = "<Put your name here> <And your email here>"
+    url = "https://github.com/lefticus/json2cpp"
+    description = "Compiles JSON into static constexpr C++ data structures with nlohmann::json API "
+    topics = ("json", "constexpr")
+
+    # Binary configuration
+    settings = "os", "compiler", "build_type", "arch"
+
+    # Sources are located in the same place as this recipe, copy them to the recipe
+    exports_sources = "CMakeLists.txt", "src/*", "include/*", "test/*", "examples/*", "cmake/*", \
+        "ProjectOptions.cmake", "Dependencies.cmake"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires("valijson/1.0", transitive_headers=True, visible=True)
+        self.requires("spdlog/1.11.0", visible=False)
+        self.requires("nlohmann_json/3.11.2", visible=False)
+        self.requires("fmt/9.1.0", visible=False)
+        self.requires("cli11/2.3.2", visible=False)
+        self.requires("ftxui/4.1.0", visible=False)
+        # self.requires("ftxui/4.1.1", visible=False)
+
+    def build_requirements(self):
+        self.test_requires("catch2/3.3.2")
+
+    def generate(self):
+        deps = CMakeDeps(self)
+        deps.generate()
+        tc = CMakeToolchain(self)
+        tc.variables["json2cpp_ENABLE_LARGE_TESTS"] = "OFF"
+        tc.variables["json2cpp_ENABLE_CLANG_TIDY"] = "OFF"
+        tc.variables["json2cpp_ENABLE_CPPCHECK"] = "OFF"
+        tc.variables["json2cpp_ENABLE_COVERAGE"] = "OFF"
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        copy(
+            self,
+            "LICENSE",
+            self.source_folder,
+            self.package_folder
+        )
+        cmake = CMake(self)
+        cmake.install()
+
+    def package_id(self):
+        # the package exports a tool and a header-only library, so compiler and
+        # build type don't matter downstream
+        self.info.settings.rm_safe("compiler")
+        self.info.settings.rm_safe("build_type")
+
+    def package_info(self):
+        self.cpp_info.components["json2cpp_headers"].set_property("cmake_target_name", "json2cpp::json2cpp_headers")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,14 @@ add_executable(json2cpp main.cpp json2cpp.cpp)
 add_executable(json2cpp::json2cpp ALIAS json2cpp)
 target_link_libraries(json2cpp PRIVATE json2cpp_options json2cpp_warnings)
 
+if(DEFINED CONAN_CXX_FLAGS)
+  find_package(fmt CONFIG)
+  find_package(spdlog CONFIG)
+  find_package(CLI11 CONFIG)
+  find_package(nlohmann_json CONFIG)
+  find_package(ValiJSON CONFIG)
+endif()
+
 target_link_system_libraries(
   json2cpp
   PRIVATE

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,7 +17,14 @@ endif()
 
 # ---- Dependencies ----
 
-include(${Catch2_SOURCE_DIR}/extras/Catch.cmake)
+if(DEFINED CONAN_CXX_FLAGS)
+  find_package(Catch2 CONFIG REQUIRED)
+  find_package(ValiJSON CONFIG REQUIRED)
+  include(Catch)
+else()
+  include(${Catch2_SOURCE_DIR}/extras/Catch.cmake)
+endif()
+
 
 
 set(BASE_NAME "${CMAKE_CURRENT_BINARY_DIR}/test_json")

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.15)
+project(PackageTest CXX)
+
+find_package(json2cpp CONFIG REQUIRED)
+
+set(COMPILED_JSON "${CMAKE_CURRENT_BINARY_DIR}/test_json")
+add_custom_command(
+        OUTPUT "${COMPILED_JSON}_impl.hpp" "${COMPILED_JSON}.hpp" "${COMPILED_JSON}.cpp"
+        COMMAND json2cpp "test_json" "${CMAKE_SOURCE_DIR}/test.json" "${COMPILED_JSON}"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+
+add_executable(example src/example.cpp "${COMPILED_JSON}.cpp")
+target_link_libraries(example PRIVATE json2cpp::json2cpp_headers)
+target_include_directories(example PRIVATE "${CMAKE_CURRENT_BINARY_DIR}")

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,0 +1,34 @@
+import os
+
+from conan import ConanFile
+from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout, CMakeDeps
+from conan.tools.build import can_run
+
+
+class json2cppTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build_requirements(self):
+        self.tool_requires(self.tested_reference_str)
+
+    def generate(self):
+        deps = CMakeDeps(self)
+        deps.generate()
+        tc = CMakeToolchain(self)
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def layout(self):
+        cmake_layout(self)
+
+    def test(self):
+        if can_run(self):
+            cmd = os.path.join(self.cpp.build.bindir, "example")
+            self.run(cmd, env="conanrun")

--- a/test_package/src/example.cpp
+++ b/test_package/src/example.cpp
@@ -1,0 +1,8 @@
+#include "test_json_impl.hpp"
+
+int main() {
+  constexpr auto &document = compiled_json::test_json::impl::document;
+  static_assert(document["glossary"]["title"].get<std::string>() == "example glossary");
+
+  return 0;
+}

--- a/test_package/test.json
+++ b/test_package/test.json
@@ -1,0 +1,25 @@
+{
+  "glossary": {
+    "title": "example glossary",
+    "GlossDiv": {
+      "title": "S",
+      "GlossList": {
+        "GlossEntry": {
+          "ID": "SGML",
+          "SortAs": "SGML",
+          "GlossTerm": "Standard Generalized Markup Language",
+          "Acronym": "SGML",
+          "Abbrev": "ISO 8879:1986",
+          "GlossDef": {
+            "para": "A meta-markup language, used to create markup languages such as DocBook.",
+            "GlossSeeAlso": [
+              "GML",
+              "XML"
+            ]
+          },
+          "GlossSee": "markup"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is a proof-of-concept of a conan 2 recipe. Since in my bubble conan is the de-facto standard I would like seeing this packaged as a conan package.
However, having two dependency managers side by side feels a little hacky. You probably want to tidy up before merging it.